### PR TITLE
Feat/person cronology and links

### DIFF
--- a/database/migrations/0002_01_01_100000_create_people_table.php
+++ b/database/migrations/0002_01_01_100000_create_people_table.php
@@ -22,8 +22,6 @@ return new class extends Migration
             $table->string('date_of_death')->nullable();
 
             $table->text('content')->nullable();
-
-            $table->longText('content')->nullable();
             $table->longText('cronology')->nullable();
 
             $table->timestamps();


### PR DESCRIPTION
This pull request makes a correction in the `create_people_table` migration file by removing a duplicate column definition.

Database migration fix:

* [`database/migrations/0002_01_01_100000_create_people_table.php`](diffhunk://#diff-fff148af6dc0e43926d52c4ea167a849c6e8f06824e5108a034db4c9a8303f85L25-L26): Removed the duplicate `content` column definition (`longText`) to avoid redundancy and potential migration issues.